### PR TITLE
Fix double_up_as_factory when the wrapped object is passed by keyword

### DIFF
--- a/i2/deco.py
+++ b/i2/deco.py
@@ -313,6 +313,34 @@ def double_up_as_factory(decorator_func):
       ...
     AssertionError: All arguments (besides the first) need to be keyword-only
 
+    Note also that the name of that first argument is effectively **reserved**: it always
+    means "the object to wrap". For a decorator that also takes ``**kwargs``, this means
+    a decorator argument can never share that name. Say a decorator's first parameter is
+    ``func`` and it renames parameters via ``**kwargs``:
+
+    >>> @double_up_as_factory
+    ... def rename(func=None, **new_name_for_old_name):
+    ...     return new_name_for_old_name  # (stand-in for the real work)
+
+    You can rename an ordinary parameter through the factory form:
+
+    >>> rename(b='bee')(lambda a, b: None)
+    {'b': 'bee'}
+
+    But you cannot use it to rename a parameter that happens to be called ``func``:
+    ``rename(func='callback')`` is read as "wrap the object ``'callback'``", not as
+    "rename ``func`` to ``callback``", so it returns nonsense rather than a factory:
+
+    >>> rename(func='callback')
+    {}
+
+    This is a pre-existing limitation of the double-up idiom -- there is no way to tell
+    the two intents apart -- and it is not specific to passing the object by keyword.
+    Before keyword-passing was supported the same call failed later and differently,
+    with ``TypeError: rename() got multiple values for argument 'func'``.  If a decorator
+    needs an argument with the same name as its first parameter, don't use
+    ``double_up_as_factory``.
+
     """
 
     def validated_wrapped_param_name(decorator_func):

--- a/i2/deco.py
+++ b/i2/deco.py
@@ -210,17 +210,35 @@ class FuncFactory:
         return FuncFactory(**jdict)
 
 
-def _double_up_as_factory(wrapped=None, *args, __decorator_func=None, **kwargs):
-    """Util for double_up_as_factory, ``__decorator_func`` to be partialized"""
+def _double_up_as_factory(
+    wrapped=None,
+    *args,
+    __decorator_func=None,
+    __wrapped_param_name=None,
+    **kwargs,
+):
+    """Util for double_up_as_factory; the ``__``-prefixed params are partialized in.
+
+    ``__decorator_func`` is the decorator being doubled up, and
+    ``__wrapped_param_name`` is the name that decorator gave its first parameter --
+    needed so that the object to wrap can be given by keyword as well as positionally.
+    """
     if args:
         raise RuntimeError(
             f"You need to specify decorator arguments as keyword-only."
             f"You specified positional arguments: {args=}"
         )
+    if wrapped is None:
+        # The object to wrap may have been given by keyword (``decorator(func=foo)``),
+        # in which case it landed in kwargs, under the decorator's first param name.
+        # Note we only look for it when nothing was given positionally: if it was given
+        # both ways, leaving kwargs alone lets python raise its own (clearer)
+        # "got multiple values for argument" TypeError.
+        wrapped = kwargs.pop(__wrapped_param_name, None)
     if wrapped is None:  # then we want a factory
         return partial(__decorator_func, **kwargs)
     else:
-        return __decorator_func(wrapped, *args, **kwargs)
+        return __decorator_func(wrapped, **kwargs)
 
 
 def double_up_as_factory(decorator_func):
@@ -246,7 +264,27 @@ def double_up_as_factory(decorator_func):
     >>> wrapped_foo = decorator(foo, multiplier=10)
     >>> wrapped_foo(2)
     30
-    >>>
+
+    The object to wrap doesn't have to be given positionally: it can also be given by
+    keyword, under the name the decorator gave its first parameter (here, ``func``).
+    This matters because forwarding arguments through ``**kwargs`` is a very common way
+    to call a decorator, so ``decorator(func=foo)`` must mean what ``decorator(foo)``
+    means:
+
+    >>> decorator(func=foo, multiplier=10)(2)
+    30
+    >>> decorator(func=foo)(2)
+    6
+
+    It is the *absence* of an object to wrap -- not the way it's passed -- that asks for
+    a factory:
+
+    >>> from functools import partial
+    >>> isinstance(decorator(multiplier=3), partial)
+    True
+    >>> isinstance(decorator(func=foo), partial)
+    False
+
     >>> multiply_by_3 = decorator(multiplier=3)
     >>> wrapped_foo = multiply_by_3(foo)
     >>> wrapped_foo(2)
@@ -277,7 +315,8 @@ def double_up_as_factory(decorator_func):
 
     """
 
-    def validate_decorator_func(decorator_func):
+    def validated_wrapped_param_name(decorator_func):
+        """Validate decorator_func, returning the name of its first parameter."""
         first_param, *other_params = signature(decorator_func).parameters.values()
         assert first_param.default is None, (
             f"First argument of the decorator function needs to default to None. "
@@ -286,12 +325,14 @@ def double_up_as_factory(decorator_func):
         assert all(
             p.kind in {p.KEYWORD_ONLY, p.VAR_KEYWORD} for p in other_params
         ), f"All arguments (besides the first) need to be keyword-only"
-        return True
-
-    validate_decorator_func(decorator_func)
+        return first_param.name
 
     return wraps(decorator_func)(
-        partial(_double_up_as_factory, __decorator_func=decorator_func)
+        partial(
+            _double_up_as_factory,
+            __decorator_func=decorator_func,
+            __wrapped_param_name=validated_wrapped_param_name(decorator_func),
+        )
     )
 
 

--- a/i2/tests/test_wrapper.py
+++ b/i2/tests/test_wrapper.py
@@ -1,9 +1,20 @@
 """Testing wrapper"""
 
 from collections.abc import Iterable
-from i2.wrapper import wrap, mk_ingress_from_name_mapper, rm_params
+from functools import partial
+
+import pytest
+
+from i2.wrapper import (
+    wrap,
+    mk_ingress_from_name_mapper,
+    rm_params,
+    ch_names,
+    include_exclude,
+    add_smart_defaults,
+)
 from i2.deco import FuncFactory
-from i2.signatures import Sig
+from i2.signatures import Sig, name_of_obj
 
 
 def _test_ingress(a, b: str, c="hi"):
@@ -425,3 +436,101 @@ def test_return_annotation_none_anywhere():
     assert sig.return_annotation is Parameter.empty
     # Test functionality
     assert wrapped(5) == 10
+
+
+# ---------------------------------------------------------------------------------------
+# double_up_as_factory: the object to wrap can be given positionally OR by keyword
+# See https://github.com/i2mint/i2/issues/64
+
+#: The ``double_up_as_factory``-built decorators of ``i2.wrapper``. Each takes the object
+#: to wrap as its first parameter (named ``func``) and every other parameter is
+#: keyword-only with a default, so each must be usable in all three of these ways:
+#: ``deco(func)``, ``deco(func=func)`` (keyword-forwarding) and ``deco(**params)(func)``
+#: (factory).
+DOUBLED_UP_DECORATORS = (wrap, ch_names, include_exclude, rm_params, add_smart_defaults)
+
+
+def _incr(x, y=1):
+    """Fixture function to be wrapped by the decorators under test."""
+    return x + y
+
+
+@pytest.mark.parametrize("decorator", DOUBLED_UP_DECORATORS, ids=name_of_obj)
+def test_double_up_as_factory_accepts_wrapped_by_keyword(decorator):
+    """``deco(func=func)`` must wrap, not silently make a factory (i2mint/i2#64).
+
+    The failure this guards against is silent: before the fix, passing the object to
+    wrap by keyword returned a ``functools.partial`` and the caller only found out much
+    later, at call time, when the "wrapped" object behaved like the decorator instead.
+    """
+    wrapped = decorator(func=_incr)
+    assert not isinstance(wrapped, partial), (
+        f"{name_of_obj(decorator)}(func=...) returned a factory instead of wrapping: "
+        f"{wrapped!r}"
+    )
+    assert wrapped(2) == _incr(2) == 3
+
+
+@pytest.mark.parametrize("decorator", DOUBLED_UP_DECORATORS, ids=name_of_obj)
+def test_double_up_as_factory_keyword_and_positional_agree(decorator):
+    """``deco(func)`` and ``deco(func=func)`` must produce equivalent wrappers."""
+    from_positional, from_keyword = decorator(_incr), decorator(func=_incr)
+    assert type(from_positional) is type(from_keyword)
+    assert from_positional(2) == from_keyword(2)
+    assert Sig(from_positional) == Sig(from_keyword)
+
+
+@pytest.mark.parametrize("decorator", DOUBLED_UP_DECORATORS, ids=name_of_obj)
+def test_double_up_as_factory_still_makes_factories(decorator):
+    """Guard: the factory direction (no object to wrap) must keep returning a partial."""
+    factory = decorator()
+    assert isinstance(factory, partial)
+    assert factory(_incr)(2) == 3
+
+
+def test_double_up_as_factory_with_decorator_params():
+    """Guard: giving decorator params (and no wrapped object) still gives a factory."""
+    from i2.deco import double_up_as_factory
+
+    @double_up_as_factory
+    def multiply_result(func=None, *, multiplier=2):
+        return lambda x: func(x) * multiplier
+
+    assert isinstance(multiply_result(multiplier=3), partial)
+    assert multiply_result(multiplier=3)(_incr)(2) == 9
+    # ... and the two non-factory directions agree
+    assert multiply_result(_incr, multiplier=3)(2) == 9
+    assert multiply_result(func=_incr, multiplier=3)(2) == 9
+
+
+def test_double_up_as_factory_honors_the_wrapped_params_name():
+    """The keyword to use is whatever the decorator named its first param."""
+    from i2.deco import double_up_as_factory
+
+    @double_up_as_factory
+    def decorate(obj=None, *, suffix="!"):
+        return lambda: obj() + suffix
+
+    hello = lambda: "hello"
+    assert decorate(obj=hello)() == "hello!"
+    assert decorate(hello)() == "hello!"
+    assert isinstance(decorate(suffix="?"), partial)
+    # ``func`` is NOT special: only the decorator's own first param name is understood
+    # as "the object to wrap", so ``func=`` stays an (here, unexpected) decorator arg,
+    # making a factory that complains only when it's used -- as it did before too.
+    unexpected_kwarg_factory = decorate(func=hello)
+    assert isinstance(unexpected_kwarg_factory, partial)
+    with pytest.raises(TypeError):
+        unexpected_kwarg_factory(hello)
+
+
+def test_double_up_as_factory_rejects_duplicate_wrapped():
+    """Giving the wrapped object both positionally and by keyword is an error."""
+    from i2.deco import double_up_as_factory
+
+    @double_up_as_factory
+    def decorate(func=None, *, multiplier=2):
+        return lambda x: func(x) * multiplier
+
+    with pytest.raises(TypeError):
+        decorate(_incr, func=_incr)


### PR DESCRIPTION
Closes #64

## The bug

`double_up_as_factory` decided between "wrap this" and "make a factory" by looking only at the first *positional* argument. So when the object to wrap was passed **by keyword** it landed in `**kwargs`, `wrapped` stayed `None`, and the decorator silently returned a `functools.partial` instead of the wrapped object:

```python
>>> wrap(foo)
<i2.Wrap foo(x)>
>>> wrap(func=foo)
functools.partial(<function wrap ...>, func=<function foo ...>)   # before
<i2.Wrap foo(x)>                                                  # after
```

There was no exception — the caller only found out much later, at call time, when the "wrapped" object behaved like the decorator. That makes it nasty: `decorator(**kwargs)` forwarding is a very common way to call a decorator, and `double_up_as_factory` is the canonical decorator idiom here, so this was latent in anything building on it.

Confirmed to affect `wrap`, `ch_names`, `include_exclude`, `rm_params` and `add_smart_defaults`.

## The fix

Partialize the decorator's first-parameter *name* into `_double_up_as_factory` alongside `__decorator_func`, and — when nothing was given positionally — take the object to wrap from `kwargs` under that name.

Two deliberate details:

- The kwargs lookup is **skipped when a positional argument was given**, so passing the object both ways still raises python's own `got multiple values for argument` `TypeError` rather than silently preferring one.
- Only the decorator's **own** first-parameter name is understood as "the object to wrap" — `func=` is not special-cased. Decorators that name it something else keep working and keep treating `func=` as an ordinary decorator argument.

The inner validator now returns that parameter name instead of `True`, so the signature is introspected once rather than twice.

Public signatures of all five decorators are byte-identical to before.

## Documented limitation (second commit)

The decorator's first parameter name is effectively **reserved** — it always means "the object to wrap". For a decorator whose first parameter is `func` and which also takes `**kwargs`, that name can therefore never be used as a decorator *argument*: `deco(func=<not-the-wrapped-object>)` is unexpressible.

This is pre-existing and **not** a regression, but the failure mode changed, so `double_up_as_factory`'s docstring now records it (with doctests):

```python
@double_up_as_factory
def rename(func=None, **new_name_for_old_name): ...

rename(b='bee')(lambda a, b: None)   # fine
rename(func='callback')              # cannot mean "rename func to callback"
```

- before: `TypeError: rename() got multiple values for argument 'func'`, raised when the factory was applied
- after: the factory call itself quietly returns nonsense

If a decorator needs an argument named the same as its first parameter, it shouldn't use `double_up_as_factory`.

## Tests

- Doctests on `double_up_as_factory` covering both call directions, the factory guard, and the reserved-name limitation above.
- Parametrized tests in `test_wrapper.py` over the five affected decorators: `f(func=foo)` wraps rather than returning a partial; the positional and keyword directions agree (same type, same result, same `Sig`); and the factory direction still returns a partial.
- Guard tests that a decorator naming its first param something other than `func` behaves correctly, and that giving the object both ways raises.

**Red before green** — the new tests fail 12/18 against the previous implementation and pass 18/18 with the fix. The new doctests were also verified red against the old logic.

## Test results

**i2**: 696 → 714 passed, 2 xfailed (`pytest --doctest-modules` with CI's option flags and ignores). No regressions.

### Dependents gate — corrected

An earlier version of this description said the dependents gate was clean — that all 46 dependents' results were "identical: 32 pass / 14 fail" with no regressions. **That was wrong, and this section replaces it.** The claim is not being deleted, it is being corrected.

The gate compared only each dependent package's **overall pass/fail status**. That is blind to a *new* failure inside a package that was **already red**: the package reads "fail" both before and after, and a status-level diff shows nothing. `meshed` is exactly that case — it carries 3 pre-existing doctest failures on its own master (`meshed/dag.py`, `meshed/makers.py`, `meshed/scrap/cached_dag.py`), so it was already "fail" and its regression was invisible to the gate.

Re-run at **per-test (node id) granularity** across i2 plus all 46 local dependents (1549 test ids before, 1567 after), the true result is:

> **1 pass → fail regression:** `meshed/tests/test_ch_funcs.py::test_ch_funcs_no_change`, failing with `TypeError: missing a required argument: 'a'`. Deterministic, A/B-verified: that file is `3 passed` against i2 master and `1 failed, 2 passed` against this branch.

That test is a **fossil of the very bug this PR fixes**, not a defect introduced by it. `meshed.dag.ch_funcs` is built on `double_up_as_factory` with first parameter `func_nodes`, so before this fix `ch_funcs(func_nodes=..., func_mapping=...)` wrongly returned a factory — and the test compensated with a trailing `()` to get its `DAG`. With the fix it returns the `DAG` directly, so that `()` calls the DAG instead. **The fix is correct; the test was written against the bug.**

Remedied by **i2mint/meshed#76**, which should land **before (or together with)** this PR. That PR is written to be safe to merge first: its new regression pin feature-detects this fix rather than pinning an unreleased i2 version, so it skips on today's i2 and starts enforcing the moment this lands.

With i2mint/meshed#76 applied, the per-test diff across i2 + 46 dependents is:

- **0 pass → fail**
- 19 tests added, all passing (18 here, plus meshed's regression pin)
- 0 tests removed, 0 other outcome or status changes

**Reproducing the per-test gate.** Same discovery and pytest invocation as `priv.dep_graph.run_dependents_tests` (`--doctest-modules`, `-o doctest_optionflags=ELLIPSIS IGNORE_EXCEPTION_DETAIL`, each repo's `exclude_paths` as `--ignore`s), plus `-v --tb=no -p no:randomly`; each `<nodeid> <OUTCOME>` line is parsed into `{package: {nodeid: outcome}}` and the two maps are diffed — instead of diffing per-package status. Run once with i2 at master and once at this branch.

### Survey for other fossils of this shape

Two independent passes over the local ecosystem, looking for other call sites that pass the wrapped object by keyword to a `double_up_as_factory`-built decorator and then call the result:

- **Static.** Enumerated every `double_up_as_factory`-built decorator and its first parameter name — i2: `wrap`, `ch_names`, `include_exclude`, `rm_params`, `add_smart_defaults`, `_conditional_arg_trans` (all `func`); meshed: `ch_funcs`, `ch_names` (`func_nodes`), `code_to_dag`, `code_to_fnodes` (`src`); front: `prepare_for_dispatch`, `store_on_output`, `prepare_for_crude_dispatch`, `inject_enum_annotations` (`func`); larder: `store_on_output` (`save_name_or_func`), `prepare_for_crude_dispatch` (`func`); plus one WIP package's `azure_wrap` (`func`). Then searched every `.py`, `.ipynb`, `.md` and `.rst` in the ecosystem for calls giving that first parameter by keyword — including multi-line calls — and for `**`-splat calls into those decorators. Also checked for aliased imports (none).
- **Dynamic.** Temporarily instrumented `_double_up_as_factory` to log every call that takes the new `kwargs.pop(...)` path, and ran the whole dependents sweep under it. This catches call sites grep cannot see, e.g. a `func=` arriving through `**kwargs` forwarding.

Both passes converge on the same **live** call site: **`meshed/tests/test_ch_funcs.py:34`** — the only one in code that any test suite executes. Every other probe hit was one of this PR's own new tests or doctests.

**Correction (found in re-review).** The static pass missed a *second* occurrence of the same fossil: `meshed/scrap/notebook.ipynb`, a 2023 scratch notebook whose saved output literally shows the bug (`functools.partial(<function ch_funcs ...>, func_nodes=...)`). It is dead code — `scrap/` is in meshed's CI `paths-to-ignore`, no notebook plugin collects it, and it produced no test change in any gate run — but re-running that notebook after this lands would raise. It is deliberately left as-is: rewriting its source without re-executing it would desynchronise the cells from their stored outputs. So the accurate statement is **one affected call site in executed code, plus one in an unexecuted scratch notebook.**

Not affected, checked explicitly: `mongodol.track_method_calls` and dol's own decorators use **dol's** separate copy of `double_up_as_factory`; `DAG.ch_funcs` and `Sig.ch_names` are ordinary methods that merely share a name with these decorators.

Caveat, stated plainly: the dynamic pass only sees code the dependents' suites actually execute, and the static pass only sees checked-in local source. A dynamic `func=` forward in untested code, or in code outside this ecosystem, would be caught by neither.

### Other notes

An apparent mongodol regression during the original gate turned out to be leftover state in a local test database, not this change — mongodol uses i2 only for `Sig`, and its `store_layers`/`wrap_kvs` come from dol's own separate `double_up_as_factory`. With a clean database, mongodol is green both with and without this change.

`dol` carries an independent copy of `double_up_as_factory` in `dol/trans.py` (not vendored from `i2/deco.py`), so this fix is i2-local. That copy looks like it has the same bug and may be worth a separate issue.

### Note for whoever merges

This repo's squash-merge default composes the merge commit body from the branch's commit
messages (`squash_merge_commit_message = COMMIT_MESSAGES`). The **first commit's message**
still contains the retracted claim that the dependents' suites were "identical ... all
pre-existing and unrelated" with no regressions. **That sentence is wrong** — see
"Dependents gate — corrected" above for what actually happened. Please either amend that
commit message or edit the squash body at merge time, so the false claim does not land in
`master`'s history. It was not amended here because rewriting already-pushed history is
outside what this session is permitted to do.

https://claude.ai/code/session_01Kug7UUbVeCQgruvNXUq63c

